### PR TITLE
edited prometheus metrics port according to tf sec.group

### DIFF
--- a/app&dockerfile/app.py
+++ b/app&dockerfile/app.py
@@ -7,7 +7,7 @@ app = Flask(__name__)
 
 
 metrics = PrometheusMetrics(app)
-metrics.start_http_server(9190, host="0.0.0.0")
+metrics.start_http_server(9100, host="0.0.0.0")
 
 
 ssm = boto3.client('ssm', region_name='eu-north-1')


### PR DESCRIPTION
What is this change?

edited prometheus metrics port according to tf sec.group

**Why is this important?**

for correct working node exporter

**How this has been tested?**
manually


**How can this be rolled back?**

Rollback can be performed by reverting these changes in source control and redeploying via standard deployment mechanisms. This change is safe to roll back.

**Are there any security risks introduced by this change?**

