### PR TITLE
added port 9100 to Dockerfile and playbook.yml

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -56,6 +56,7 @@
       image: pavlotarnovetskyi/flaskapp_jenkins
       ports:
        - 5000:5000
+       - 9100:9100
     
 
 

--- a/app&dockerfile/Dockerfile
+++ b/app&dockerfile/Dockerfile
@@ -6,6 +6,6 @@ COPY . /app
 
 RUN pip3 --no-cache-dir install -r requirements.txt
 
-EXPOSE 5000
+EXPOSE 5000 9100
 
 CMD ["python3", "app.py"]


### PR DESCRIPTION
What is this change?

added port 9100 to Dockerfile and playbook.yml

**Why is this important?**

allow to work node exporter metrics

**How this has been tested?**

manually

**How can this be rolled back?**

Rollback can be performed by reverting these changes in source control and redeploying via standard deployment mechanisms. This change is safe to roll back.

**Are there any security risks introduced by this change?**

