### PR TITLE
added stage to substitute instance ip in prometheus.yml

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,7 +59,13 @@ pipeline {
                     }    
                 }
             }
-        }            
+        }
+        stage('Substitute public ip in prometheus.yml & restart prometheus'){
+            steps{
+                sh 'chmod +x ./terraform/script.sh'
+                sh './terraform/script.sh'
+            }            
+        }             
     }
 
     post

--- a/terraform/script.sh
+++ b/terraform/script.sh
@@ -1,0 +1,5 @@
+!/bin/bash
+Public_IP=`terraform output public_ip | sed 's/.\\(.*\\)/\\1/' | sed 's/\\(.*\\)./\\1/'`
+echo $Public_IP
+sed -i -e "s/'\\(.*\\):9100'/'$Public_IP:9100'/g" /usr/local/etc/prometheus.yml
+brew services restart prometheus

--- a/terraform/script.sh
+++ b/terraform/script.sh
@@ -1,4 +1,4 @@
-!/bin/bash
+#!/bin/bash
 Public_IP=`terraform output public_ip | sed 's/.\\(.*\\)/\\1/' | sed 's/\\(.*\\)./\\1/'`
 echo $Public_IP
 sed -i -e "s/'\\(.*\\):9100'/'$Public_IP:9100'/g" /usr/local/etc/prometheus.yml


### PR DESCRIPTION
What is this change?

added stage in the pipeline to substitute instance IP  in prometheus.yml

**Why is this important?**

step to automatisation

**How this has been tested?**

manually

**How can this be rolled back?**

Rollback can be performed by reverting these changes in source control and redeploying via standard deployment mechanisms. This change is safe to roll back.

**Are there any security risks introduced by this change?**

