### PR TITLE
Pometheus

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,7 @@ pipeline {
     tools {
         dockerTool 'docker'
     }    
+    
     environment{
         dockerImage = ''
         registryCredential   = 'dockerhub-creds'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
 
     tools {
         dockerTool 'docker'
-    }    
+    }
     
     environment{
         dockerImage = ''
@@ -12,6 +12,7 @@ pipeline {
         registry = "pavlotarnovetskyi/flaskapp_jenkins"
     }
     
+
     stages {
         stage('Cloning our Git '){
             steps{
@@ -61,9 +62,16 @@ pipeline {
         }
         stage('Substitute public ip in prometheus.yml & restart prometheus'){
             steps{
-                sh 'chmod +x ./terraform/script.sh'
-                sh './terraform/script.sh'
-            }            
+                dir('./terraform'){
+                    sh '''
+                    #!/bin/bash
+                    Public_IP=`terraform output public_ip | sed \'s/.\\\\(.*\\\\)/\\\\1/\' | sed \'s/\\\\(.*\\\\)./\\\\1/\'`
+                    echo $Public_IP
+                    sed -i -e "s/\'\\(.*\\\\):9100\'/\'$Public_IP:9100\'/g" /usr/local/etc/prometheus.yml
+                    brew services restart prometheus
+                    '''
+                }    
+            }                 
         }             
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,15 +4,13 @@ pipeline {
 
     tools {
         dockerTool 'docker'
-    }
-    
+    }    
     environment{
         dockerImage = ''
         registryCredential   = 'dockerhub-creds'
         registry = "pavlotarnovetskyi/flaskapp_jenkins"
     }
     
-
     stages {
         stage('Cloning our Git '){
             steps{

--- a/terraform/script.sh
+++ b/terraform/script.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-Public_IP=`terraform output public_ip | sed 's/.\\(.*\\)/\\1/' | sed 's/\\(.*\\)./\\1/'`
-echo $Public_IP
-sed -i -e "s/'\(.*\\):9100'/'$Public_IP:9100'/g" /usr/local/etc/prometheus.yml
-brew services restart prometheus


### PR DESCRIPTION
What is this change?

updated script that substitute public IP EC2 instance into prometheus.yml

**Why is this important?**
server monitoring infrastructure automatization


**How this has been tested?**

manually

**How can this be rolled back?**

Rollback can be performed by reverting these changes in source control and redeploying via standard deployment mechanisms. This change is safe to roll back.

**Are there any security risks introduced by this change?**

